### PR TITLE
fix(Code): Add enum type decorator to status property in DockerfileBaseResponseDto

### DIFF
--- a/server/src/dockerfiles/dto/dockerfile-base.response.dto.ts
+++ b/server/src/dockerfiles/dto/dockerfile-base.response.dto.ts
@@ -12,6 +12,9 @@ export abstract class DockerfileBaseResponseDto {
 	 */
 	id: string
 
+	@ApiProperty({
+		enum: DockerfileStatus,
+	})
 	/**
 	 * Current processing state of the Dockerfile.
 	 */


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved API documentation by specifying the possible values for the status field in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Close #60